### PR TITLE
Add action for branch and line coverage check

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -58,3 +58,38 @@ jobs:
         uses: ./spellings
         with:
           path: coreMQTT
+  test-coverage-cop:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
+        with:
+          repository: FreeRTOS/coreMQTT
+          ref: main
+          path: coreMQTT
+      - name: Build
+        run: |
+          sudo apt-get install -y lcov
+          cmake -S ./coreMQTT/test -B build/ \
+          -G "Unix Makefiles" \
+          -DCMAKE_BUILD_TYPE=Debug \
+          -DBUILD_CLONE_SUBMODULES=ON \
+          -DCMAKE_C_FLAGS='--coverage -Wall -Wextra -Werror -DNDEBUG -DLIBRARY_LOG_LEVEL=LOG_DEBUG'
+          make -C build/ all
+      - name: Test
+        run: |
+          cd build/
+          ctest -E system --output-on-failure
+          cd ..
+      - name: Run Coverage
+        run: |
+          make -C build/ coverage
+          declare -a EXCLUDE=("\*test/\*" "\*CMakeCCompilerId\*" "\*mocks\*")
+          echo ${EXCLUDE[@]} | xargs lcov --rc lcov_branch_coverage=1 -r build/coverage.info -o build/coverage.info
+          lcov --rc lcov_branch_coverage=1 --list build/coverage.info
+      - name: Test coverage cop action
+        uses: ./coverage-cop
+        with:
+          path: ./build/coverage.info
+          branch-min-coverage: 100
+          line-min-coverage: 99

--- a/README.md
+++ b/README.md
@@ -8,3 +8,4 @@ Currently, this repository contains actions for the following code quality check
 * **Doxygen** - Validates that the doxygen manual of the FreeRTOS library can be built without warnings.
 * **Spellings** - Checks spellings across all files of the
 FreeRTOS library repository. Each FreeRTOS library repository should have a **lexicon.txt** file.
+* **Coverage Cop** - Enforces that the unit tests of a FreeRTOS library meet the minimum thresholds branch and line coverages. The **lcov** coverage output from running unit tests should be available before using this action.

--- a/coverage-cop/action.yml
+++ b/coverage-cop/action.yml
@@ -1,0 +1,36 @@
+name: 'coverage-cop'
+description: 'CI Check Coverage results of unit tests (using lcov)'
+inputs:
+  path:
+    description: 'Path to lcov output file containing coverage data.'
+    required: true
+  branch-min-coverage:
+    description: 'The minumum required branch coverage (in %) for success'
+    required: false
+    default: 100
+  line-min-coverage:
+    description: 'The minumum required line coverage (in %) for success'
+    required: false
+    default: 100
+runs:
+  using: "composite"
+  steps: 
+      - run: |
+          sudo apt-get install lcov
+          LINE_COVERAGE=$(lcov --list ${{ inputs.path }} | tail -n 1 | cut -d '|' -f 2 | sed -n "s/\([^%]*\)%.*/\1/p")
+          BRANCH_COVERAGE=$(lcov --rc lcov_branch_coverage=1 --list ${{ inputs.path }} | tail -n 1 | cut -d '|' -f 4 | sed -n "s/\([^%]*\)%.*/\1/p")
+          RESULT=0
+          echo "Required line coverage: ${{ inputs.line-min-coverage }}"
+          echo "Line coverage:   $LINE_COVERAGE"
+          if [[ $(echo "$LINE_COVERAGE < ${{ inputs.line-min-coverage }}" | bc) -ne 0 ]]; then
+            echo "Line Coverage is too low."
+            RESULT=1
+          fi
+          echo "Required branch coverage: ${{ inputs.line-min-coverage }}"
+          echo "Branch coverage: $BRANCH_COVERAGE"
+          if [[ $(echo "$BRANCH_COVERAGE < $${{ inputs.line-branch-coverage }}" | bc) -ne 0 ]]; then
+            echo "Branch Coverage is too low."
+            RESULT=1
+          fi
+          exit $RESULT
+        shell: bash


### PR DESCRIPTION
Add a GitHub Action for checking the line and branch coverages of the unit tests of a FreeRTOS library. The action takes the input parameters of: 
1) (Required) Path to the coverage file generated by **lcov** from running unit tests 
2) (Optional) The minimum line coverage requirement (default is 100%)  
3) (Optional) The minimum branch coverage requirement (default is 100%)