### PR TITLE
Update memory_statistics to use config file

### DIFF
--- a/.github/coreMQTT_memory_statistics_config.json
+++ b/.github/coreMQTT_memory_statistics_config.json
@@ -1,0 +1,15 @@
+{
+    "lib_name": "coreMQTT",
+    "src": [
+        "source/core_mqtt.c",
+        "source/core_mqtt_state.c",
+        "source/core_mqtt_serializer.c"
+    ],
+    "include": [
+        "source/include",
+        "source/interface"
+    ],
+    "compiler_flags": [
+        "MQTT_DO_NOT_USE_CUSTOM_CONFIG"
+    ]
+}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -108,16 +108,7 @@ jobs:
         uses: ./memory_statistics
         with:
           path: coreMQTT
-          lib_name: coreMQTT
-          src: |
-            source/core_mqtt.c
-            source/core_mqtt_state.c
-            source/core_mqtt_serializer.c
-          include: |
-            source/include
-            source/interface
-          compiler_flags: |
-            MQTT_DO_NOT_USE_CUSTOM_CONFIG
+          config: ../.github/coreMQTT_memory_statistics_config.json
       - name: Upload table
         uses: actions/upload-artifact@v2
         with:

--- a/memory_statistics/action.yml
+++ b/memory_statistics/action.yml
@@ -6,7 +6,7 @@ inputs:
     required: false
     default: ./
   config:
-    description: 'Configuration json file for memory estimation.'
+    description: 'JSON config file containing library information to be used for memory estimation.'
     required: true
   output:
     description: 'File to write generated table to.'

--- a/memory_statistics/action.yml
+++ b/memory_statistics/action.yml
@@ -12,6 +12,10 @@ inputs:
     description: 'File to write generated table to.'
     required: false
     default: 'size_table.html'
+  check_against:
+    description: 'If set, the generated table will be compared against the given file, failing if not the same.'
+    required: false
+    default: ''
   toolchain_link:
     description: 'Link to ARM GCC tar.bz2 to use for compiling files (default version 9-2020-q2).'
     required: false
@@ -29,4 +33,16 @@ runs:
           ${{ github.action_path }}/memory_statistics.py
           --config "${{ inputs.config }}"
           --output "${{ inputs.output }}"
+      shell: bash
+    - name: Compare table
+      run: |
+          if [ "x${{ inputs.check_against }}" != "x" ] ; then
+              if cmp "${{ inputs.check_against }}" "${{ inputs.output }}" ; then
+                  exit 0
+              else
+                  echo "Size table does not match!"
+                  diff -U 2 "${{ inputs.check_against }}" "${{ inputs.output }}"
+                  exit 1
+              fi
+          fi
       shell: bash

--- a/memory_statistics/action.yml
+++ b/memory_statistics/action.yml
@@ -5,19 +5,9 @@ inputs:
     description: 'Path to library directory.'
     required: false
     default: ./
-  lib_name:
-    description: 'Library name for table header.'
+  config:
+    description: 'Configuration json file for memory estimation.'
     required: true
-  src:
-    description: 'Files to measure size of, newline delimited.'
-    required: true
-  include:
-    description: 'Include directories, newline delimited.'
-    required: true
-  compiler_flags:
-    description: 'Extra compiler flags, newline delimited.'
-    required: false
-    default: ''
   output:
     description: 'File to write generated table to.'
     required: false
@@ -37,9 +27,6 @@ runs:
       working-directory: ${{ inputs.path }}
       run: >-
           ${{ github.action_path }}/memory_statistics.py
-          --name "${{ inputs.lib_name }}"
-          --sources "${{ inputs.src }}"
-          --includes "${{ inputs.include }}"
-          --flags "${{ inputs.compiler_flags }}"
+          --config "${{ inputs.config }}"
           --output "${{ inputs.output }}"
       shell: bash

--- a/memory_statistics/action.yml
+++ b/memory_statistics/action.yml
@@ -13,7 +13,9 @@ inputs:
     required: false
     default: 'size_table.html'
   check_against:
-    description: 'If set, the generated table will be compared against the given file, failing if not the same.'
+    description: >
+        Path to existing memory estimates file to compare with the memory estimates calculated by
+        the action. Action will fail if sizes do not match to indicate need for updating size.
     required: false
     default: ''
   toolchain_link:

--- a/memory_statistics/action.yml
+++ b/memory_statistics/action.yml
@@ -36,7 +36,7 @@ runs:
       shell: bash
     - name: Compare table
       run: |
-          if [ "x${{ inputs.check_against }}" != "x" ] ; then
+          if [ -n "${{ inputs.check_against }}" ] ; then
               if cmp "${{ inputs.check_against }}" "${{ inputs.output }}" ; then
                   exit 0
               else

--- a/memory_statistics/memory_statistics.py
+++ b/memory_statistics/memory_statistics.py
@@ -40,13 +40,15 @@ def convert_size_to_kb(byte_size):
 
 
 def parse_make_output(output, values, key):
-    # output expects the output of the makefile, which ends in a call to
-    # arm-none-eabi-size The output of size is expected to be the Berkley
-    # output format: text data bss dec hex filename
-    #
-    # values is an input defaultdict which maps filenames to dicts of opt level
-    # to sizes. This function adds each file's size to the file's dict with the
-    # key provided by the key parameter.
+    '''
+    output expects the output of the makefile, which ends in a call to
+    arm-none-eabi-size The output of size is expected to be the Berkley output
+    format: text data bss dec hex filename
+
+    values is an input defaultdict which maps filenames to dicts of opt level
+    to sizes. This function adds each file's size to the file's dict with the
+    key provided by the key parameter.
+    '''
     output = output.splitlines()
 
     # Skip to size output
@@ -119,12 +121,13 @@ def parse_arguments():
 def main():
     args = parse_arguments()
 
-    # Config file should contain a json object with the following keys:
-    #   "lib_name": Name to use for the library in the table header
-    #   "src": Array of source paths to measure sizes of
-    #   "include": Array of include directories
-    #   "compiler_flags": (optional) Array of extra flags to use for compiling
-
+    '''
+    Config file should contain a json object with the following keys:
+      "lib_name": Name to use for the library in the table header
+      "src": Array of source paths to measure sizes of
+      "include": Array of include directories
+      "compiler_flags": (optional) Array of extra flags to use for compiling
+    '''
     with open(args['config']) as config_file:
         config = json.load(config_file)
 


### PR DESCRIPTION
Since the library configuration is taken on the command line, it has to
be duplicated at all the call sites of the action. This has the action
get the library config from a config file so that multiple workflows can use the
same config. This will also aid the action's use in the hub repos.