### PR TITLE
Include data section in memory estimates

### DIFF
--- a/memory_statistics/memory_statistics.py
+++ b/memory_statistics/memory_statistics.py
@@ -82,9 +82,9 @@ def parse_make_output(output, values, key):
         # parts[1] is the data size
         data_size = int(parts[1].strip())
 
-        size_in_kb = convert_size_to_kb(text_size + data_size)
+        total_size_in_kb = convert_size_to_kb(text_size + data_size)
 
-        values[filename][key] = size_in_kb
+        values[filename][key] = total_size_in_kb
 
 
 def parse_to_table(o1_output, os_output, name):

--- a/memory_statistics/memory_statistics.py
+++ b/memory_statistics/memory_statistics.py
@@ -2,6 +2,7 @@
 
 import os
 import sys
+import shutil
 import argparse
 import subprocess
 import json
@@ -129,6 +130,10 @@ def parse_arguments():
 
 def main():
     args = parse_arguments()
+
+    if not shutil.which("arm-none-eabi-gcc"):
+        print("ARM GCC not found. Please add the ARM GCC toolchain to your path.")
+        sys.exit(1)
 
     '''
     Config file should contain a json object with the following keys:

--- a/memory_statistics/memory_statistics.py
+++ b/memory_statistics/memory_statistics.py
@@ -38,7 +38,7 @@ def make(sources, includes, flags, opt):
 
 
 def convert_size_to_kb(byte_size):
-    kb_size = round(int(byte_size)/1024,1)
+    kb_size = round(byte_size/1024,1)
     if (kb_size == 0.0):
         return 0.1
     else:
@@ -77,10 +77,13 @@ def parse_make_output(output, values, key):
             filename += " (third-party utility)"
 
         # parts[0] is the text size
-        text_size = parts[0].strip()
-        text_size_in_kb = convert_size_to_kb(text_size)
+        text_size = int(parts[0].strip())
+        # parts[1] is the data size
+        data_size = int(parts[1].strip())
 
-        values[filename][key] = text_size_in_kb
+        size_in_kb = convert_size_to_kb(text_size + data_size)
+
+        values[filename][key] = size_in_kb
 
 
 def parse_to_table(o1_output, os_output, name):


### PR DESCRIPTION
The data section's initialization values are stored in flash so should be included when estimating flash size.