### PR TITLE
Improve readability of coverage-cop action

### DIFF
--- a/coverage-cop/action.yml
+++ b/coverage-cop/action.yml
@@ -15,8 +15,13 @@ inputs:
 runs:
   using: "composite"
   steps: 
-      - run: |
-          sudo apt-get install lcov
+      - name: Print coverage data
+        run: lcov --list --rc lcov_branch_coverage=1 ${{ inputs.path }}
+        shell: bash
+      - name: Install lcov (if not present)
+        run: sudo apt-get install lcov
+      - name: Check coverage
+        run: |
           LINE_COVERAGE=$(lcov --list ${{ inputs.path }} | tail -n 1 | cut -d '|' -f 2 | sed -n "s/\([^%]*\)%.*/\1/p")
           BRANCH_COVERAGE=$(lcov --rc lcov_branch_coverage=1 --list ${{ inputs.path }} | tail -n 1 | cut -d '|' -f 4 | sed -n "s/\([^%]*\)%.*/\1/p")
           RESULT=0

--- a/coverage-cop/action.yml
+++ b/coverage-cop/action.yml
@@ -20,6 +20,7 @@ runs:
         shell: bash
       - name: Install lcov (if not present)
         run: sudo apt-get install lcov
+        shell: bash
       - name: Check coverage
         run: |
           LINE_COVERAGE=$(lcov --list ${{ inputs.path }} | tail -n 1 | cut -d '|' -f 2 | sed -n "s/\([^%]*\)%.*/\1/p")


### PR DESCRIPTION
Improve usability of coverage-cop action by printing the coverage table in logs of the calling CI workflow runs.