### PR TITLE
Support exclusion of files and directories in formatting check

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,6 +21,8 @@ jobs:
         uses: ./formatting
         with:
           path: coreMQTT
+          exclude-files: lexicon.txt
+          exclude-dirs: build;docs
   test-complexity-check:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,7 +22,7 @@ jobs:
         with:
           path: coreMQTT
           exclude-files: lexicon.txt
-          exclude-dirs: build;docs
+          exclude-dirs: build,docs
   test-complexity-check:
     runs-on: ubuntu-latest
     steps:

--- a/formatting/action.yml
+++ b/formatting/action.yml
@@ -28,7 +28,7 @@ runs:
         working-directory: ${{ inputs.path }}
         run: |
           set +e
-          grep --exclude={README.md,${{ inputs.exclude-files }}} --exclude-dir={${{ inputs.exclude-dirs }}} -rnI -e "[[:blank:]]$" .
+          grep --exclude={README.md,${{ inputs.exclude-files }}} --exclude-dir={${{ inputs.exclude-dirs }},''} -rnI -e "[[:blank:]]$" .
           if [ "$?" = "0" ]; then
             echo "Files have trailing whitespace."
             exit 1

--- a/formatting/action.yml
+++ b/formatting/action.yml
@@ -5,6 +5,14 @@ inputs:
     description: 'Path to repository folder to run formatting check for.'
     required: false
     default: ./
+  exclude-files:
+    description: 'List of comma-separated files to exclude from formatting check. Eg file1,file2'
+    required: false
+    default: ''
+  exclude-dirs:
+    description: 'List of comma-separated directories to exclude from formatting check. Eg docs,build'
+    required: false
+    default: ''
 runs:
   using: "composite"
   steps: 
@@ -20,7 +28,7 @@ runs:
         working-directory: ${{ inputs.path }}
         run: |
           set +e
-          grep --exclude="README.md" -rnI -e "[[:blank:]]$" .
+          grep --exclude={README.md,${{ inputs.exclude-files }}} --exclude-dir={${{ inputs.exclude-dirs }}} -rnI -e "[[:blank:]]$" .
           if [ "$?" = "0" ]; then
             echo "Files have trailing whitespace."
             exit 1


### PR DESCRIPTION
Add input parameters to `formatting` action to allow calling CI workflow to specify list of files and directories to exclude from formatting check.