### PR TITLE
Fix URL search regex in link verifier

### DIFF
--- a/link-verifier/verify-links.py
+++ b/link-verifier/verify-links.py
@@ -15,7 +15,7 @@ import traceback
 
 MARKDOWN_SEARCH_TERM = r'\.md$'
 # Regex to find a URL
-URL_SEARCH_TERM = r'(\b(https?|ftp|file)://[^\s\)\]\\"<>]+[^\s\)\.\]]\\"<>)'
+URL_SEARCH_TERM = r'(\b(https?|ftp|file)://[^\s\)\]\\"<>]+[^\s\)\.\]\\"<>])'
 HTTP_URL_SEARCH_TERM = r'https?://'
 # Some HTML tags that we choose to ignore
 IGNORED_LINK_SCHEMES = r'mailto:|ftp:|tel:'


### PR DESCRIPTION
Fix the regex string used to match URLs in the link verifier script.