### PR TITLE
Avoid symlinks in formatting check

### DIFF
--- a/formatting/action.yml
+++ b/formatting/action.yml
@@ -6,11 +6,11 @@ inputs:
     required: false
     default: ./
   exclude-files:
-    description: 'List of comma-separated files to exclude from formatting check. Eg file1,file2'
+    description: 'List of comma-separated files to exclude from trailing whitespace check. Eg file1,file2'
     required: false
     default: ''
   exclude-dirs:
-    description: 'List of comma-separated directories to exclude from formatting check. Eg docs,build'
+    description: 'List of comma-separated directories to exclude from trailing whitespace formatting check. Eg docs,build'
     required: false
     default: ''
 runs:

--- a/formatting/action.yml
+++ b/formatting/action.yml
@@ -22,7 +22,8 @@ runs:
       - name: Run Uncrustify
         working-directory: ${{ inputs.path }}
         run: |
-          find . -iname "*.[hc]" -exec uncrustify --check -c $GITHUB_ACTION_PATH/uncrustify.cfg -l C {} +
+          # Run uncrustify on C files while ignoring symlinks.
+          find . -iname "*.[hc]" -type f -exec uncrustify --check -c $GITHUB_ACTION_PATH/uncrustify.cfg -l C {} +
         shell: bash
       - name: Check For Trailing Whitespace
         working-directory: ${{ inputs.path }}

--- a/spellings/tools/README.md
+++ b/spellings/tools/README.md
@@ -6,26 +6,25 @@
    apt-get install util-linux
    ```
 
-1. Add the folder containing the **tools/spell/ablexicon**, **tools/spell/extract-comments**, and **tools/spell/find-unknown-comment-words** scripts to your system's PATH.
+1. Add the folder containing the **spellings/tools/ablexicon**, **spellings/tools/extract-comments**, and **spellings/tools/find-unknown-comment-words** scripts to your system's PATH.
    ```shell
-   export PATH=<CSDK_ROOT>/tools/spell:$PATH
+   export PATH=<REPO_ROOT>/spellings/tools:$PATH
    ```
 
 # How to create a lexicon.txt for a new library.
 
-1. Ensure there does not exist a file called "lexicon.txt" in your library's directory. Run the following command to create a lexicon.txt for your library:
+1. Ensure there does not exist a file called "lexicon.txt" in your library's root directory. Run the following command to create a lexicon.txt for your library:
    ```shell
-   find-unknown-comment-words -d <CSDK_ROOT>/libraries/<LIBRARY_TYPE>/<MY_LIBRARY_NAME> > <CSDK_ROOT>/libraries/<LIBRARY_TYPE>/<MY_LIBRARY_NAME>/words.txt
-   mv <CSDK_ROOT>/libraries/<LIBRARY_TYPE>/<MY_LIBRARY_NAME>/words.txt <CSDK_ROOT>/libraries/<LIBRARY_TYPE>/<MY_LIBRARY_NAME>/lexicon.txt
+   find-unknown-comment-words -d /path/to/your/library/root > /path/to/your/library/root/lexicon.txt
    ```
 
-1. Check the contents of *<CSDK_ROOT>/libraries/<LIBRARY_TYPE>/<MY_LIBRARY_NAME>/lexicon.txt* for any misspelled words. Fix them in your library's source code and delete them from the lexicon.txt.
+1. Check the contents of */path/to/your/library/root/lexicon.txt* for any misspelled words. Fix them in your library's source code and delete them from the lexicon.txt.
 
 # How to run for changes to an existing library.
 
-1. If there exists a lexicon.txt in the library's directory, run the following command:
+1. If there exists a lexicon.txt in the library's root directory, run the following command:
    ```shell
-   find-unknown-comment-words -d <CSDK_ROOT>/libraries/<LIBRARY_TYPE>/<MY_LIBRARY_NAME>
+   find-unknown-comment-words -d /path/to/your/library/root/lexicon.txt
    ```
 
-1. Add any non-dictionary correctly spelled words to *<CSDK_ROOT>/libraries/<LIBRARY_TYPE>/<MY_LIBRARY_NAME>/lexicon.txt*. Fix any misspelled words in your code comment change.
+1. Add any non-dictionary correctly spelled words to */path/to/your/library/root/lexicon.txt*. Fix any misspelled words in your code comment change.


### PR DESCRIPTION
Update the **formatting** action to avoid checking symlink files. Also, make hygiene fixes to documentation for **spellings** check.