### PR TITLE
Ignore symlinks from spell checks

### DIFF
--- a/spellings/tools/find-unknown-comment-words
+++ b/spellings/tools/find-unknown-comment-words
@@ -83,7 +83,7 @@ fi
 
 TMPFILE=${0##*/}-$USER-$RANDOM
 unknowns=( "not-used" )     # get around empty array with nounset
-extract-comments `find $DIRNAME \( -iname \*.[ch] -o -iname \*.dox \)` |
+extract-comments `find $DIRNAME \( -iname \*.[ch] -o -iname \*.dox \) -type f` |
     tr [:upper:] [:lower:] |
     grep -o -E '[a-zA-Z]+' |
     ablexicon -l $LEXICON > $TMPFILE
@@ -103,7 +103,7 @@ do
         continue
     fi
 
-    for file in `find $DIRNAME \( -iname \*.[ch] -o -iname \*.dox \)`
+    for file in `find $DIRNAME \( -iname \*.[ch] -o -iname \*.dox \) -type f`
     do
         if [[ $file == *"third_party"*  || $file == *"CMock"* ]]
         then

--- a/spellings/tools/find-unknown-comment-words
+++ b/spellings/tools/find-unknown-comment-words
@@ -83,6 +83,7 @@ fi
 
 TMPFILE=${0##*/}-$USER-$RANDOM
 unknowns=( "not-used" )     # get around empty array with nounset
+# Symlinks will be ignored in this spell check. `-type f` switch in `find` command will ignore symlinks.
 extract-comments `find $DIRNAME \( -iname \*.[ch] -o -iname \*.dox \) -type f` |
     tr [:upper:] [:lower:] |
     grep -o -E '[a-zA-Z]+' |
@@ -103,6 +104,7 @@ do
         continue
     fi
 
+    # Symlinks will be ignored in this spell check. `-type f` switch in `find` command will ignore symlinks.
     for file in `find $DIRNAME \( -iname \*.[ch] -o -iname \*.dox \) -type f`
     do
         if [[ $file == *"third_party"*  || $file == *"CMock"* ]]


### PR DESCRIPTION
Ignore symlinks from spell checks. 

Symlinks caused an issue in spell checks. Fixing it by avoiding symlinks in the spell checks.