### PR TITLE
Update doxygen action dependencies

### DIFF
--- a/doxygen/action.yml
+++ b/doxygen/action.yml
@@ -24,7 +24,7 @@ runs:
     - name: Install Doxygen
       run: |
         wget -qO- "${{ inputs.doxygen_link }}" | sudo tar --strip-components=1 -xz -C /usr/local
-        sudo apt-get install -y libclang-9-dev graphviz
+        sudo apt-get install -y libclang-9-dev libclang-cpp9 graphviz
       shell: bash
     - name: Verify Doxygen build and Generate ZIP (if specified)
       working-directory: ${{ inputs.path }}


### PR DESCRIPTION
Fix failures in doxygen action builds from missing dependency on `libclang-cpp.so.9`. Example of failing build: https://github.com/FreeRTOS/corePKCS11/runs/2634817705