### PR TITLE
Support FreeRTOS/coreSNTP in memory statistics script

### DIFF
--- a/memory_statistics/paths.json
+++ b/memory_statistics/paths.json
@@ -14,6 +14,9 @@
     "corePKCS11": {
         "path": "FreeRTOS-Plus/Source/corePKCS11"
     },
+    "coreSNTP": {
+        "path": "FreeRTOS-Plus/Source/Application-Protocols/coreSNTP"
+    },
     "shadow": {
         "path": "FreeRTOS-Plus/Source/AWS/device-shadow"
     },


### PR DESCRIPTION
Add path to `FreeRTOS/coreSNTP` library to `memory_statistics/paths.json` file so that the script for generating memory statistics includes the `coreSNTP` library as well.