### PR TITLE
Added action for generating and pushing doxygen

### DIFF
--- a/doxygen-generation/action.yml
+++ b/doxygen-generation/action.yml
@@ -18,7 +18,7 @@ runs:
       shell: bash
       run: |
         wget -O doxygen.tgz "https://sourceforge.net/projects/doxygen/files/rel-1.9.2/doxygen-1.9.2.linux.bin.tar.gz"
-        if [ $? -ne 0 ]; exit 1; fi
+        if [ $? -ne 0 ]; then exit 1; fi
         sudo tar --strip-components=1 -xzf doxygen.tgz -C /usr/local
         sudo apt-get install -y libclang-9-dev libclang-cpp9 graphviz
 
@@ -27,7 +27,7 @@ runs:
       shell: bash
       run: |
         doxygen docs/doxygen/config.doxyfile 2>&1 | tee doxyoutput.txt
-        if [[ "$(wc -c < doxyoutput.txt | bc)" = "0" ]]; then exit 0; else exit 1; fi
+        if [ "$(wc -c < doxyoutput.txt | bc)" = "0" ]; then exit 0; else exit 1; fi
 
     - name: Checkout the repo for storing doxygen
       uses: actions/checkout@v2

--- a/doxygen-generation/action.yml
+++ b/doxygen-generation/action.yml
@@ -17,7 +17,9 @@ runs:
     - name: Install Doxygen
       shell: bash
       run: |
-        wget -qO- "https://sourceforge.net/projects/doxygen/files/rel-1.9.2/doxygen-1.9.2.linux.bin.tar.gz" | sudo tar --strip-components=1 -xz -C /usr/local
+        wget -O doxygen.tgz "https://sourceforge.net/projects/doxygen/files/rel-1.9.2/doxygen-1.9.2.linux.bin.tar.gz"
+        if [ $? -ne 0 ]; exit 1; fi
+        sudo tar --strip-components=1 -xzf doxygen.tgz -C /usr/local
         sudo apt-get install -y libclang-9-dev libclang-cpp9 graphviz
 
     - name: Generate doxygen
@@ -64,6 +66,9 @@ runs:
         git config --global user.email ${{ github.actor }}@users.noreply.github.com
         commit_id=$(git rev-parse ${{ inputs.ref }})
         git add ${{ inputs.ref }}
-        # Allowing empty commit in case the doxygen for new commit is identical to previous.
-        git commit --allow-empty -m "Doxygen for ${commit_id}"
-        git push origin gh-pages
+        # Only commit if doxygen is changed.
+        changed=$(git diff-index HEAD)
+        if [ -n "$changed" ]; then
+          git commit -m "Doxygen for ${commit_id}"
+          git push origin gh-pages
+        fi

--- a/doxygen-generation/action.yml
+++ b/doxygen-generation/action.yml
@@ -1,8 +1,8 @@
 name: 'doxygen-generation'
 description: 'Generate doxygen documentation and push to gh-pages branch'
 inputs:
-  branch:
-    description: ''
+  ref:
+    description: 'Reference (e.g. branch or tag) to the commit for generating doxygen'
     required: false
     default: 'main'
 runs:
@@ -12,7 +12,7 @@ runs:
       uses: actions/checkout@v2
       with:
         path: doxygen_source
-        ref: ${{ inputs.branch }}
+        ref: ${{ inputs.ref }}
 
     - name: Install Doxygen
       shell: bash
@@ -53,8 +53,8 @@ runs:
     - name: Replace previous doxygen documentation
       shell: bash
       run: |
-        rm -rf doxygen_store/${{ inputs.branch }}
-        mv doxygen_source/docs/doxygen/output/html doxygen_store/${{ inputs.branch }}
+        rm -rf doxygen_store/${{ inputs.ref }}
+        mv doxygen_source/docs/doxygen/output/html doxygen_store/${{ inputs.ref }}
 
     - name: Commit new doxygen
       working-directory: ./doxygen_store
@@ -62,8 +62,8 @@ runs:
       run: |
         git config --global user.name ${{ github.actor }}
         git config --global user.email ${{ github.actor }}@users.noreply.github.com
-        commit_id=$(git rev-parse ${{ inputs.branch }})
-        git add ${{ inputs.branch }}
+        commit_id=$(git rev-parse ${{ inputs.ref }})
+        git add ${{ inputs.ref }}
         # Allowing empty commit in case the doxygen for new commit is identical to previous.
         git commit --allow-empty -m "Doxygen for ${commit_id}"
         git push origin gh-pages

--- a/doxygen-generation/action.yml
+++ b/doxygen-generation/action.yml
@@ -1,0 +1,69 @@
+name: 'doxygen-generation'
+description: 'Generate doxygen documentation and push to gh-pages branch'
+inputs:
+  branch:
+    description: ''
+    required: false
+    default: 'main'
+runs:
+  using: "composite"
+  steps:
+    - name: Checkout the repo for generating doxygen
+      uses: actions/checkout@v2
+      with:
+        path: doxygen_source
+        ref: ${{ inputs.branch }}
+
+    - name: Install Doxygen
+      shell: bash
+      run: |
+        wget -qO- "https://sourceforge.net/projects/doxygen/files/rel-1.9.2/doxygen-1.9.2.linux.bin.tar.gz" | sudo tar --strip-components=1 -xz -C /usr/local
+        sudo apt-get install -y libclang-9-dev libclang-cpp9 graphviz
+
+    - name: Generate doxygen
+      working-directory: ./doxygen_source
+      shell: bash
+      run: |
+        doxygen docs/doxygen/config.doxyfile 2>&1 | tee doxyoutput.txt
+        if [[ "$(wc -c < doxyoutput.txt | bc)" = "0" ]]; then exit 0; else exit 1; fi
+
+    - name: Checkout the repo for storing doxygen
+      uses: actions/checkout@v2
+      with:
+        path: doxygen_store
+
+    - name: Switch to gh-pages branch
+      working-directory: ./doxygen_store
+      shell: bash
+      run: |
+        # Check if the gh-pages branch exists. If not, create it.
+        branch_exist=$(git ls-remote --heads origin gh-pages)
+        if [ -z ${branch_exist} ]; then
+          git config --global user.name ${{ github.actor }}
+          git config --global user.email ${{ github.actor }}@users.noreply.github.com
+          git checkout --orphan gh-pages
+          git reset --hard
+          git commit --allow-empty -m "Created gh-pages branch"
+          git push origin gh-pages
+        fi
+        # Switch to gh-pages branch
+        git fetch
+        git checkout gh-pages
+
+    - name: Replace previous doxygen documentation
+      shell: bash
+      run: |
+        rm -rf doxygen_store/${{ inputs.branch }}
+        mv doxygen_source/docs/doxygen/output/html doxygen_store/${{ inputs.branch }}
+
+    - name: Commit new doxygen
+      working-directory: ./doxygen_store
+      shell: bash
+      run: |
+        git config --global user.name ${{ github.actor }}
+        git config --global user.email ${{ github.actor }}@users.noreply.github.com
+        commit_id=$(git rev-parse ${{ inputs.branch }})
+        git add ${{ inputs.branch }}
+        # Allowing empty commit in case the doxygen for new commit is identical to previous.
+        git commit --allow-empty -m "Doxygen for ${commit_id}"
+        git push origin gh-pages


### PR DESCRIPTION
### Description
This PR adds a doxygen-generation action. This action generates doxygen documentation for a given branch (defaults to main) and pushes the documentation onto `gh-pages` branch used for Github Pages. This action can be shared between different repos, thus placing in CI-CD-Github-Actions repo.

### Test
Tested on my fork of Fleet-Provisioning-for-AWS-IoT-embedded-sdk. A [workflow](https://github.com/tianmc1/Fleet-Provisioning-for-AWS-IoT-embedded-sdk/blob/main/.github/workflows/doxygen-generation.yml) is created using this action. On the first run, `gh-pages` branch was created. On a commit that doesn't change doxygen, no new commits are pushed to gh-pages. On a commit that changes doxygen, a new commit is pushed to gh-pages.