### PR TITLE
Add and mainain `latest` link in doxygen deployment

### DIFF
--- a/doxygen-generation/action.yml
+++ b/doxygen-generation/action.yml
@@ -92,13 +92,15 @@ runs:
         jq '.branches//=["main"]' > tmp.json
         mv tmp.json _data/doc_config.json
 
-    - name: Add to release list
+    - name: Add to release list and update latest
       if: inputs.add_release != 'false'
-      working-directory: ./doxygen_store/_data
+      working-directory: ./doxygen_store/
       shell: bash
       run: |
-        jq '.releases|=if index("${{ inputs.ref }}") then . else ["${{ inputs.ref }}"]+. end' doc_config.json > tmp.json
-        mv tmp.json doc_config.json
+        jq '.releases|=if index("${{ inputs.ref }}") then . else ["${{ inputs.ref }}"]+. end' _data/doc_config.json > tmp.json
+        mv tmp.json _data/doc_config.json
+        rm -f latest
+        ln -s "${{ inputs.ref }}" latest
 
     - name: Commit new doxygen
       working-directory: ./doxygen_store


### PR DESCRIPTION
Update the doxygen deployment action to include a latest symlink in the gh-pages branch.

This enables using links to a page in the documentation for the latest release, as exist on AWS Docs.