### PR TITLE
Add SigV4 and Fleet Provisioning to FreeRTOS/FreeRTOS paths

### DIFF
--- a/memory_statistics/paths.json
+++ b/memory_statistics/paths.json
@@ -31,5 +31,11 @@
     },
     "ota": {
         "path": "FreeRTOS-Plus/Source/AWS/ota"
+    },
+    "sigv4": {
+        "path": "FreeRTOS-Plus/Source/AWS/sigv4"
+    },
+    "fleetprovisioning": {
+        "path": "FreeRTOS-Plus/Source/AWS/fleet-provisioning"
     }
 }


### PR DESCRIPTION
Add SigV4 and Fleet Provisioning to libraries included in FreeRTOS/FreeRTOS json memory estimates report.