### PR TITLE
Update Doxygen generation version to 1.9.4

### DIFF
--- a/doxygen-generation/action.yml
+++ b/doxygen-generation/action.yml
@@ -20,9 +20,9 @@ inputs:
     required: false
     default: docs/doxygen/output/html
   doxygen_link:
-    description: 'Download link for doxygen tar.gz (default version 1.9.2).'
+    description: 'Download link for doxygen tar.gz (default version 1.9.5).'
     required: false
-    default: "https://sourceforge.net/projects/doxygen/files/rel-1.9.2/doxygen-1.9.2.linux.bin.tar.gz"
+    default: "https://sourceforge.net/projects/doxygen/files/rel-1.9.5/doxygen-1.9.5.linux.bin.tar.gz"
   doxygen_dependencies:
     description: 'Space-separated dependencies for doxygen.'
     required: false

--- a/doxygen-generation/action.yml
+++ b/doxygen-generation/action.yml
@@ -20,9 +20,9 @@ inputs:
     required: false
     default: docs/doxygen/output/html
   doxygen_link:
-    description: 'Download link for doxygen tar.gz (default version 1.9.5).'
+    description: 'Download link for doxygen tar.gz (default version 1.9.4).'
     required: false
-    default: "https://sourceforge.net/projects/doxygen/files/rel-1.9.5/doxygen-1.9.5.linux.bin.tar.gz"
+    default: "https://sourceforge.net/projects/doxygen/files/rel-1.9.4/doxygen-1.9.4.linux.bin.tar.gz"
   doxygen_dependencies:
     description: 'Space-separated dependencies for doxygen.'
     required: false

--- a/doxygen/action.yml
+++ b/doxygen/action.yml
@@ -10,9 +10,9 @@ inputs:
     required: false
     default: ./
   doxygen_link:
-    description: 'Download link for doxygen tar.gz (default version 1.9.5).'
+    description: 'Download link for doxygen tar.gz (default version 1.9.4).'
     required: false
-    default: "https://sourceforge.net/projects/doxygen/files/rel-1.9.5/doxygen-1.9.5.linux.bin.tar.gz"
+    default: "https://sourceforge.net/projects/doxygen/files/rel-1.9.4/doxygen-1.9.4.linux.bin.tar.gz"
   doxygen_dependencies:
     description: 'Space-separated dependencies for doxygen.'
     required: false


### PR DESCRIPTION
### Description
Update the `doxygen-generation` action to use Doxygen 1.9.4. This is required because once we update our spoke repos consuming this to 1.9.5 the doxygen file will have 1.9.4 config options. 1.9.2 may no longer work.

### Testing
This one isn't so easily tested as this action is used in the CI.