### PR TITLE
Update doxygen to 1.9.6

### DIFF
--- a/doxygen-generation/action.yml
+++ b/doxygen-generation/action.yml
@@ -20,9 +20,9 @@ inputs:
     required: false
     default: docs/doxygen/output/html
   doxygen_link:
-    description: 'Download link for doxygen tar.gz (default version 1.9.4).'
+    description: 'Download link for doxygen tar.gz (default version 1.9.6).'
     required: false
-    default: "https://sourceforge.net/projects/doxygen/files/rel-1.9.4/doxygen-1.9.4.linux.bin.tar.gz"
+    default: "https://sourceforge.net/projects/doxygen/files/rel-1.9.6/doxygen-1.9.6.linux.bin.tar.gz"
   doxygen_dependencies:
     description: 'Space-separated dependencies for doxygen.'
     required: false

--- a/doxygen/action.yml
+++ b/doxygen/action.yml
@@ -10,9 +10,9 @@ inputs:
     required: false
     default: ./
   doxygen_link:
-    description: 'Download link for doxygen tar.gz (default version 1.9.4).'
+    description: 'Download link for doxygen tar.gz (default version 1.9.6).'
     required: false
-    default: "https://sourceforge.net/projects/doxygen/files/rel-1.9.4/doxygen-1.9.4.linux.bin.tar.gz"
+    default: "https://sourceforge.net/projects/doxygen/files/rel-1.9.6/doxygen-1.9.6.linux.bin.tar.gz"
   doxygen_dependencies:
     description: 'Space-separated dependencies for doxygen.'
     required: false


### PR DESCRIPTION
### Description
This recently released doxygen version
does not have false parameter warnings
like 1.9.5.

### Testing
Manually verified links work. This will unblock other PRs which update doxygen versions.