### PR TITLE
Switch to libclang 11 for doxygen-generation step

### DIFF
--- a/doxygen-generation/action.yml
+++ b/doxygen-generation/action.yml
@@ -26,7 +26,7 @@ inputs:
   doxygen_dependencies:
     description: 'Space-separated dependencies for doxygen.'
     required: false
-    default: libclang-9-dev libclang-cpp9 graphviz
+    default: libclang-11-dev libclang-cpp11 graphviz
 
 runs:
   using: "composite"


### PR DESCRIPTION
### Description
Libclang 9 packages are no longer available on the latest Ubuntu (22.04). Libclang 11 instead must be used.

See https://packages.ubuntu.com/search?keywords=libclang&searchon=names&suite=jammy&section=all