### PR TITLE
Update the run cbmc runner action to use echo groups

### DIFF
--- a/run_cbmc/action.yml
+++ b/run_cbmc/action.yml
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: MIT-0
 # CBMC starter kit 2.9
 name: Run CBMC
+description: 'Action that runs the CBMC proofs inside of a FreeRTOS Repository'
 inputs:
   proofs_dir:
     required: true
@@ -18,38 +19,96 @@ inputs:
 runs:
   using: composite
   steps:
-    - name: Run CBMC
+    - env:
+        bashPass: \033[32;1mPASSED -
+        bashInfo: \033[33;1mINFO -
+        bashFail: \033[31;1mFAILED -
+        bashEnd:  \033[0m
+        stepName: Run CBMC
+      name: ${{ env.stepName }}
       shell: bash
       working-directory: ${{ inputs.proofs_dir }}
-      run: ${{ inputs.run_cbmc_proofs_command }}
-    - name: Check repository visibility
+      run: |
+        # ${{ env.stepName }}
+        echo -e "::group::${{ env.bashInfo }} ${{ env.stepName }} ${{ env.bashEnd }}"
+        ${{ inputs.run_cbmc_proofs_command }}
+        echo -e "::endgroup::"
+        echo -e "${{ env.bashPass }} ${{ env.stepName }} ${{ env.bashEnd }}"
+
+    - env:
+        bashPass: \033[32;1mPASSED -
+        bashInfo: \033[33;1mINFO -
+        bashFail: \033[31;1mFAILED -
+        bashEnd:  \033[0m
+        stepName: Check repository visibility
+      name: ${{ env.stepName }}
       shell: bash
       run: |
+        # ${{ env.stepName }}
+        echo -e "::group::${{ env.bashInfo }} ${{ env.stepName }} ${{ env.bashEnd }}"
         VIZ="${{ fromJson(toJson(github.event.repository)).visibility }}";
         echo "REPO_VISIBILITY=${VIZ}" | tee -a "${GITHUB_ENV}";
-    - name: Set name for zip artifact with CBMC proof results
+
+    - env:
+        bashPass: \033[32;1mPASSED -
+        bashInfo: \033[33;1mINFO -
+        bashFail: \033[31;1mFAILED -
+        bashEnd:  \033[0m
+        stepName: Set name for zip artifact with CBMC proof results
+      name: ${{ env.stepName }}
       shell: bash
       id: artifact
       if: ${{ env.REPO_VISIBILITY == 'public' }}
       run: |
+        # ${{ env.stepName }}
+        echo -e "::group::${{ env.bashInfo }} ${{ env.stepName }} ${{ env.bashEnd }}"
         echo "name=cbmc_proof_results_${{ fromJson(toJson(github.event.repository)).name }}_$(date +%Y_%m_%d_%H_%M_%S)" >> $GITHUB_OUTPUT
-    - name: Create zip artifact with CBMC proof results
+        echo -e "::endgroup::"
+        echo -e "${{ env.bashPass }} ${{ env.stepName }} ${{ env.bashEnd }}"
+
+    - env:
+        bashPass: \033[32;1mPASSED -
+        bashInfo: \033[33;1mINFO -
+        bashFail: \033[31;1mFAILED -
+        bashEnd:  \033[0m
+        stepName: Create zip artifact with CBMC proof results
+      name: ${{ env.stepName }}
       if: ${{ env.REPO_VISIBILITY == 'public' }}
       shell: bash
       run: |
+        # ${{ env.stepName }}
+        echo -e "::group::${{ env.bashInfo }} ${{ env.stepName }} ${{ env.bashEnd }}"
         FINAL_REPORT_DIR="${{ inputs.proofs_dir }}/output/latest/html"
         pushd $FINAL_REPORT_DIR \
           && zip -r ${{ steps.artifact.outputs.name }}.zip . \
           && popd \
           && mv $FINAL_REPORT_DIR/${{ steps.artifact.outputs.name }}.zip .
-    - name: Upload zip artifact of CBMC proof results to GitHub Actions
+        echo -e "::endgroup::"
+        echo -e "${{ env.bashPass }} ${{ env.stepName }} ${{ env.bashEnd }}"
+
+    - env:
+        bashPass: \033[32;1mPASSED -
+        bashInfo: \033[33;1mINFO -
+        bashFail: \033[31;1mFAILED -
+        bashEnd:  \033[0m
+        stepName: Upload zip artifact of CBMC proof results to GitHub Actions
+      name: ${{ env.stepName }}
       if: ${{ env.REPO_VISIBILITY == 'public' }}
       uses: actions/upload-artifact@v3
       with:
         name: ${{ steps.artifact.outputs.name }}
         path: ${{ steps.artifact.outputs.name }}.zip
-    - name: CBMC proof results
+
+    - env:
+        bashPass: \033[32;1mPASSED -
+        bashInfo: \033[33;1mINFO -
+        bashFail: \033[31;1mFAILED -
+        bashEnd:  \033[0m
+        stepName: CBMC proof results
+      name: ${{ env.stepName }}
       shell: bash
       run: |
+        # ${{ env.stepName }}
+        echo -e "${{ env.bashInfo }} ${{ env.stepName }} ${{ env.bashEnd }}"
         python3 ${{ inputs.proofs_dir }}/lib/summarize.py \
           --run-file ${{ inputs.proofs_dir }}/output/latest/html/run.json


### PR DESCRIPTION
Use echo groups for CBMC proofs. 
Example of new output for run CBMC runner can be found [here](https://github.com/FreeRTOS/coreMQTT/actions/runs/6475640446/job/17583010708#step:3:1)