### PR TITLE
Update link verifier to use Python 3.7 and urllib3 v2

### DIFF
--- a/link-verifier/action.yml
+++ b/link-verifier/action.yml
@@ -29,6 +29,8 @@ runs:
   steps:
   - name: Setup Python for link verifier action
     uses: actions/setup-python@v3
+    with:
+      python-version: '3.7' # Minimum version for urllib v2 (https://urllib3.readthedocs.io/en/latest/v2-migration-guide.html)
 
   - env:
       # The bash escape character is \033

--- a/link-verifier/requirements.txt
+++ b/link-verifier/requirements.txt
@@ -6,4 +6,4 @@ idna==2.10
 requests==2.31.0
 soupsieve==2.1
 termcolor==1.1.0
-urllib3
+urllib3>=2.0.7


### PR DESCRIPTION
### Description
This is done to resolve two dependabot alerts.

https://github.com/aws/aws-iot-device-sdk-embedded-C/security/dependabot/9
https://github.com/aws/aws-iot-device-sdk-embedded-C/security/dependabot/8

### Testing
* Cloned repository
* Made modifications to action + requirements.txt
* `pip install -r requirements.txt`

Ran two tests....
```
verify-links.py -F fileTests/goodFiles/fileWithLowercasemdIntheName.md
```
No error as expected

```
verify-links.py -F fileTests/badFiles/fileWithLowercasemdIntheNameAndABrokenLink.md 
FILE: fileTests/badFiles/fileWithLowercasemdIntheNameAndABrokenLink.md
  404	https://github.com/FreeRTOS/A-Repo-That-Wins-You-The-Lottery
1 broken link
```
Errors as expected