### PR TITLE
Run Apt Update and Upgrade before apt installs

### DIFF
--- a/spellings/action.yml
+++ b/spellings/action.yml
@@ -33,6 +33,8 @@ runs:
       echo -e "::group::${{ env.bashInfo }} ${{ env.stepName }} ${{ env.bashEnd }}"
 
       # Install the Dependencies we need to run the spell-checker
+      sudo apt-get update -y
+      sudo apt-get upgrade -y
       sudo apt-get install util-linux -y
       sudo apt-get install fd-find -y
       sudo apt-get install npm -y


### PR DESCRIPTION
Without running an apt update/upgrade before installing dependencies old versions can get pulled. This is causing the spell checker to fail to install, as seen [here](https://github.com/FreeRTOS/CI-CD-Github-Actions/actions/runs/6960283667/job/18939410884#step:4:404)

This PR provides a fix for this action to immediately fix the CI-CD, a PR to ensure this happens in all actions shall follow.