### PR TITLE
Tie CBMC to 5.95.1 given 6.0.0 alpha is causing PR's to fail

### DIFF
--- a/.github/workflows/pr_checks.yml
+++ b/.github/workflows/pr_checks.yml
@@ -28,6 +28,7 @@ jobs:
               run-link-verifier: true,
               run-complexity: false,
               run-doxygen: false,
+              exclude-dirs: portable
             },
             {
               repository: FreeRTOS-Plus-TCP,

--- a/.github/workflows/pr_checks.yml
+++ b/.github/workflows/pr_checks.yml
@@ -28,7 +28,6 @@ jobs:
               run-link-verifier: true,
               run-complexity: false,
               run-doxygen: false,
-              exclude-dirs: portable
             },
             {
               repository: FreeRTOS-Plus-TCP,
@@ -324,6 +323,7 @@ jobs:
               repository: FreeRTOS-Kernel,
               org: FreeRTOS,
               branch: main,
+              exclude-dirs: portable
             },
             {
               repository: FreeRTOS-Plus-TCP,

--- a/.github/workflows/pr_checks.yml
+++ b/.github/workflows/pr_checks.yml
@@ -334,7 +334,7 @@ jobs:
               repository: FreeRTOS,
               org: FreeRTOS,
               branch: main,
-              exclude-dirs: ethernet, drivers, FreeRTOS/Demo
+              exclude-dirs: [ethernet, drivers, FreeRTOS/Demo]
             },
             {
               repository: FreeRTOS-Cellular-Interface,

--- a/.github/workflows/pr_checks.yml
+++ b/.github/workflows/pr_checks.yml
@@ -334,6 +334,7 @@ jobs:
               repository: FreeRTOS,
               org: FreeRTOS,
               branch: main,
+              exclude-dirs: ethernet, drivers, FreeRTOS/Demo
             },
             {
               repository: FreeRTOS-Cellular-Interface,

--- a/.github/workflows/pr_checks.yml
+++ b/.github/workflows/pr_checks.yml
@@ -419,4 +419,4 @@ jobs:
         with:
           path: repo/${{ matrix.inputs.repository }}
           exclude-files: ${{ matrix.inputs.exclude-files }}
-          exclude-dirs: ethernet, drivers, FreeRTOS/Demo
+          exclude-dirs: ${{ matrix.inputs.exclude-dirs }}

--- a/.github/workflows/pr_checks.yml
+++ b/.github/workflows/pr_checks.yml
@@ -323,7 +323,7 @@ jobs:
               repository: FreeRTOS-Kernel,
               org: FreeRTOS,
               branch: main,
-              exclude-dirs: portable
+              exclude-dirs: 'portable'
             },
             {
               repository: FreeRTOS-Plus-TCP,
@@ -334,7 +334,7 @@ jobs:
               repository: FreeRTOS,
               org: FreeRTOS,
               branch: main,
-              exclude-dirs: ethernet, drivers, FreeRTOS/Demo
+              exclude-dirs: 'ethernet, drivers, FreeRTOS/Demo'
             },
             {
               repository: FreeRTOS-Cellular-Interface,

--- a/.github/workflows/pr_checks.yml
+++ b/.github/workflows/pr_checks.yml
@@ -334,7 +334,7 @@ jobs:
               repository: FreeRTOS,
               org: FreeRTOS,
               branch: main,
-              exclude-dirs: [ethernet, drivers, FreeRTOS/Demo]
+              exclude-dirs: ethernet, drivers, FreeRTOS/Demo
             },
             {
               repository: FreeRTOS-Cellular-Interface,

--- a/set_up_cbmc_runner/action.yml
+++ b/set_up_cbmc_runner/action.yml
@@ -4,9 +4,9 @@
 name: Set up CBMC runner
 inputs:
   cbmc_version:
-    description: Version number or 'latest' for CBMC
+    description: Version number or '5.95.1' for CBMC
     required: true
-    default: latest
+    default: 5.95.1
   cbmc_viewer_version:
     description: Version number or 'latest' for CBMC Viewer
     required: true

--- a/set_up_cbmc_runner/action.yml
+++ b/set_up_cbmc_runner/action.yml
@@ -4,7 +4,7 @@
 name: Set up CBMC runner
 inputs:
   cbmc_version:
-    description: Version number or '5.95.1' for CBMC
+    description: Version number or '5.95.1' for CBMC. NOTE: This is because of the fact that the 6.0.0 alpha release isn't meant for production use. When the full release happens this should be set back to using the 'latest' https://github.com/diffblue/cbmc/releases/tag/cbmc-6.0.0-alpha
     required: true
     default: 5.95.1
   cbmc_viewer_version:


### PR DESCRIPTION
CBMC proofs in our repositories that default to using the latest version of CBMC are currently failing due to either a bug or breaking change in the pre-production version of cbmc 6.0.0. Tying the CBMC version to 5.95.1 (latest stable, working release on our repos) to resolve this issue in the meantime. Please revert this change once there is a new production release.

**Note**: There is a message on the latest release of CBMC stating "This release is to test our infrastructure and shouldn't be used in a production setting."