### PR TITLE
Remove colon in description that was causing action to fail

### DIFF
--- a/set_up_cbmc_runner/action.yml
+++ b/set_up_cbmc_runner/action.yml
@@ -4,7 +4,7 @@
 name: Set up CBMC runner
 inputs:
   cbmc_version:
-    description: Version number or '5.95.1' for CBMC. NOTE: This is because of the fact that the 6.0.0 alpha release isn't meant for production use. When the full release happens this should be set back to using the 'latest' https://github.com/diffblue/cbmc/releases/tag/cbmc-6.0.0-alpha
+    description: Version number or '5.95.1' for CBMC. NOTE This is because of the fact that the 6.0.0 alpha release isn't meant for production use. When the full release happens this should be set back to using the 'latest' https://github.com/diffblue/cbmc/releases/tag/cbmc-6.0.0-alpha
     required: true
     default: 5.95.1
   cbmc_viewer_version:

--- a/set_up_cbmc_runner/action.yml
+++ b/set_up_cbmc_runner/action.yml
@@ -4,7 +4,8 @@
 name: Set up CBMC runner
 inputs:
   cbmc_version:
-    description: Version number or '5.95.1' for CBMC. NOTE This is because of the fact that the 6.0.0 alpha release isn't meant for production use. When the full release happens this should be set back to using the 'latest' https://github.com/diffblue/cbmc/releases/tag/cbmc-6.0.0-alpha
+    # NOTE This is because of the fact that the 6.0.0 alpha release isn't meant for production use. When the full release happens this should be set back to using the 'latest' https://github.com/diffblue/cbmc/releases/tag/cbmc-6.0.0-alpha
+    description: Version number or '5.95.1' for CBMC.
     required: true
     default: 5.95.1
   cbmc_viewer_version:


### PR DESCRIPTION
The colon resulted in the following error: FreeRTOS/CI-CD-Github-Actions/main/set_up_cbmc_runner/action.yml: (Line: 7, Col: 59, Idx: 232) - (Line: 7, Col: 59, Idx: 232): Mapping values are not allowed in this context. 