### PR TITLE
Correct SPDX ID

### DIFF
--- a/sbom-generator/sbom_utils.py
+++ b/sbom-generator/sbom_utils.py
@@ -22,7 +22,7 @@ def package_hash(file_list: str) -> str:
 
 def file_writer(output, filepath: str, sha1: str, license: str, copyright='NOASSERTION', comment='NOASSERTION'):
     output.write('FileName: .'+ filepath + '\n')
-    output.write('SPDXID: SPDXRef-File'+ filepath.replace('/', '-') + '\n')
+    output.write('SPDXID: SPDXRef-File'+ filepath.replace('/', '-').replace('_', '') + '\n')
     output.write('FileChecksum: SHA1: '+ sha1 + '\n')
     output.write('LicenseConcluded: '+ license + '\n')
     output.write('FileCopyrightText: '+ copyright + '\n')
@@ -30,12 +30,14 @@ def file_writer(output, filepath: str, sha1: str, license: str, copyright='NOASS
     output.write('\n')
 
 def package_writer(output, packageName: str, version: str, url: str, license: str, ver_code: str, file_analyzed=True,
-                   copyright='NOASSERTION', summary='NOASSERTION', description='NOASSERTION'):
+                   copyright='NOASSERTION', summary='NOASSERTION', description='NOASSERTION', file_licenses='NOASSERTION'):
     output.write('PackageName: '+ packageName + '\n')
     output.write('SPDXID: SPDXRef-Package-'+ packageName + '\n')
     output.write('PackageVersion: '+ version + '\n')
     output.write('PackageDownloadLocation: '+ url + '\n')
+    output.write('PackageLicenseDeclared: ' + license + '\n')
     output.write('PackageLicenseConcluded: '+ license + '\n')
+    output.write('PackageLicenseInfoFromFiles: '+ file_licenses + '\n')
     output.write('FilesAnalyzed: '+ str(file_analyzed) + '\n')
     output.write('PackageVerificationCode: '+ ver_code + '\n')
     output.write('PackageCopyrightText: '+ copyright + '\n')
@@ -52,7 +54,7 @@ def doc_writer(output, version: str, name: str, creator_comment='NOASSERTION',
     output.write('SPDXID: SPDXRef-DOCUMENT\n')
     output.write('DocumentName: ' + name + '\n')
     output.write('DocumentNamespace: ' + namespace + '\n')
-    output.write('Creator: ' + CREATOR + '\n')
+    output.write('Creator: Organization:' + CREATOR + '\n')
     output.write('Created: ' + today.isoformat()[:-7] + 'Z\n')
     output.write('CreatorComment: ' + creator_comment + '\n')
     output.write('DocumentComment: ' + doc_comment + '\n')


### PR DESCRIPTION
### Description
SPDX ID should not contain underscore characters.
Packages are required to have a declared license
and license info from files field.

Ref
* https://spdx.github.io/spdx-spec/v2.2.2/file-information/#821-description
* https://spdx.github.io/spdx-spec/v2.2.2/package-information/

### Issues
https://github.com/FreeRTOS/FreeRTOS-Kernel/issues/928

### Manual testing steps
Generated a new SBOM with the 10.51 version checked out with the following command...
```
python3 scan_dir.py --source-path /Users/kstribrnAmzn/workspace/FreeRTOS-Kernel --repo-root-path /Users/kstribrnAmzn/workspace/FreeRTOS-Kernel
```

Verified output through SPDX checker.

![Screenshot 2023-12-20 at 2 54 41 PM](https://github.com/FreeRTOS/CI-CD-Github-Actions/assets/89810515/d32671ec-0253-4c74-997f-6f378830d05f)

Can share generated SPDX SBOM as needed. Key changes are...
The new package fields
```
PackageName: FreeRTOS-Kernel
SPDXID: SPDXRef-Package-FreeRTOS-Kernel
PackageVersion: v10.5.1
PackageDownloadLocation: https://github.com/FreeRTOS-Kernel/tree/v10.5.1
PackageLicenseDeclared: MIT   #THIS ONE IS NEW
PackageLicenseConcluded: MIT
PackageLicenseInfoFromFiles: NOASSERTION. #THIS ONE IS NEW
FilesAnalyzed: True
PackageVerificationCode: 0be52506eca522ee26211d8b17212b88375c10f2
PackageCopyrightText: NOASSERTION
PackageSummary: NOASSERTION
PackageDescription: FreeRTOS Kernel.
```

And the fixed SPDX ID for files. The old one is invalid
```
SPDXID: SPDXRef-File-portable-IAR-ARM_CM35P-secure-secure_init.c
```
The new one is valid
```
SPDXID: SPDXRef-File-portable-IAR-ARMCM33-secure-secureinit.c
```

### Unit tests
None added

### Integration tests
May need to be updated

### Deployment ordering
N/A - Single package change

### Backward compatibility of data and changes
#### Is the change rollback friendly? Think about state in DynamoDB or other resources created by the new code and whether the old code can handle it. 
This change can easily be reverted. No backwards compatibility concerns.

### Metrics and instrumentation
N/A