### PR TITLE
Use cspell version 8.3.1

### DIFF
--- a/spellings/action.yml
+++ b/spellings/action.yml
@@ -38,7 +38,7 @@ runs:
       sudo apt-get install util-linux -y
       sudo apt-get install fd-find -y
       sudo apt-get install npm -y
-      sudo npm install -g cspell
+      sudo npm install -g cspell@8.3.1
 
       # Add the Github Action Path to PATH
       export PATH="$GITHUB_ACTION_PATH:$PATH"


### PR DESCRIPTION
CSpell Version 8.3.2 "catches" spelling issues that CSpell 8.3.1 does not flag.
Difference between CSpell 8.3.1 and 8.3.2 can be seen by comparing the [first](https://github.com/FreeRTOS/FreeRTOS/actions/runs/7382599380/attempts/1) and second [run](https://github.com/FreeRTOS/FreeRTOS/actions/runs/7382599380/job/20206024754) of this workflow, where the check fails due to the difference.
Difference can also be seen in the trigger Repo Check workflow [here](https://github.com/FreeRTOS/CI-CD-Github-Actions/actions/runs/7425182917) 

For now tie the version of cspell to 8.3.1.