### PR TITLE
Remove Unnecessary Apt Upgrade From Spellings

### DIFF
--- a/spellings/action.yml
+++ b/spellings/action.yml
@@ -34,7 +34,6 @@ runs:
 
       # Install the Dependencies we need to run the spell-checker
       sudo apt-get update -y
-      sudo apt-get upgrade -y
       sudo apt-get install util-linux -y
       sudo apt-get install fd-find -y
       sudo apt-get install npm -y


### PR DESCRIPTION
Admittedly not very important, but you should only need the apt update portion to fix the Node.js problem that was occurring. The apt upgrade portion just wastes time upgrading firefox and other stuff. It added a minute to the spellings action from before/after the fix.