### PR TITLE
sbom-generator: Fix FilesAnalyzed boolean value

### DIFF
--- a/sbom-generator/sbom_utils.py
+++ b/sbom-generator/sbom_utils.py
@@ -38,7 +38,7 @@ def package_writer(output, packageName: str, version: str, url: str, license: st
     output.write('PackageLicenseDeclared: ' + license + '\n')
     output.write('PackageLicenseConcluded: '+ license + '\n')
     output.write('PackageLicenseInfoFromFiles: '+ file_licenses + '\n')
-    output.write('FilesAnalyzed: '+ str(file_analyzed) + '\n')
+    output.write('FilesAnalyzed: '+ str(file_analyzed).lower() + '\n')
     output.write('PackageVerificationCode: '+ ver_code + '\n')
     output.write('PackageCopyrightText: '+ copyright + '\n')
     output.write('PackageSummary: '+ summary + '\n')


### PR DESCRIPTION
The FilesAnalyzed boolean value as per SPDX spec is lowercase.

Spec:
https://spdx.github.io/spdx-spec/v2.3/package-information/#7.8

Without this fix, the generated SPDX SBOM fails the validator tool. https://github.com/spdx/tools-java/releases
```
$ java -jar tools-java-1.1.8-jar-with-dependencies.jar Verify sbom.spdx
This SPDX Document is not valid due to:
Warning: Invalid case for boolean value.  Expected 'true', found 'True'
```

https://tools.spdx.org/app/validate/
```
The following warning(s) were raised:<br />
Warning: Invalid case for boolean value. Expected 'true', found 'True'
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.