### PR TITLE
Fix doxygen generation by removing symlink and replacing with folder

### DIFF
--- a/doxygen-generation/action.yml
+++ b/doxygen-generation/action.yml
@@ -107,8 +107,9 @@ runs:
       run: |
         jq '.releases|=if index("${{ inputs.ref }}") then . else ["${{ inputs.ref }}"]+. end' _data/doc_config.json > tmp.json
         mv tmp.json _data/doc_config.json
-        rm -f latest
-        ln -s "${{ inputs.ref }}" latest
+        rm -rf latest
+        mkdir latest
+        cp -r "${{ inputs.ref }}"/* latest
 
     - name: Commit new doxygen
       working-directory: ./doxygen_store


### PR DESCRIPTION
*Issue #, if available:*

Github doesn't allow symlinks in gh-pages anymore while deploying doxygen.
Example: https://github.com/FreeRTOS/coreMQTT/runs/24619176608

*Description of changes:*
This PR fixes this issue by replacing the symlink and copying the contents to separate folder.
Thanks @kstribrnAmzn for figuring this out.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
