### PR TITLE
Add option for host address in echo server and MQTT broker

### DIFF
--- a/.github/workflows/pr_checks.yml
+++ b/.github/workflows/pr_checks.yml
@@ -349,6 +349,7 @@ jobs:
               repository: FreeRTOS-Plus-TCP,
               org: FreeRTOS,
               branch: main,
+              exclude-dirs: source/portable/NetworkInterface/STM32
             },
             {
               repository: FreeRTOS,

--- a/.github/workflows/pr_checks.yml
+++ b/.github/workflows/pr_checks.yml
@@ -38,6 +38,7 @@ jobs:
               run-spelling-check: true,
               run-complexity: false,
               run-doxygen: false,
+              exclude-dirs: source/portable/NetworkInterface/STM32
             },
             {
               repository: FreeRTOS,

--- a/localhost-echo-server/action.yml
+++ b/localhost-echo-server/action.yml
@@ -2,6 +2,10 @@ name: 'Localhost Echo Server'
 description: 'Starts an echo server using Python.'
 
 inputs:
+  host_address:
+    description: "Host address for echo server."
+    required: false
+    default: "127.0.0.1"
   port_number:
     description: "Port for echo server."
     required: True
@@ -13,5 +17,10 @@ runs:
       shell: bash
       run: |
         python3 --version
-        python3 $GITHUB_ACTION_PATH/local_echo_server.py --port_number=${{ inputs.port_number }} &
+        # Use the host_address input if provided, otherwise default to 127.0.0.1
+        HOST=${{ inputs.host_address }}
+        if [[ -z "$HOST" ]]; then
+          HOST="127.0.0.1"
+        fi
+        python3 $GITHUB_ACTION_PATH/local_echo_server.py --host=$HOST --port_number=${{ inputs.port_number }} &
 

--- a/localhost-echo-server/local_echo_server.py
+++ b/localhost-echo-server/local_echo_server.py
@@ -17,6 +17,10 @@ async def echo_handler(reader, writer):
 
 if __name__ == '__main__':
   parser = ArgumentParser(description='Localhost Echo server.')
+  parser.add_argument('--host',
+                      type=str,
+                      required=True,
+                      help='Host address for the echo server.')
   parser.add_argument('--port_number',
                       type=int,
                       required=True,
@@ -28,7 +32,7 @@ if __name__ == '__main__':
   asyncio.set_event_loop(loop)
   factory = asyncio.start_server(
     echo_handler,
-    os.environ.get('HOST'),
+    os.environ.get('HOST', args.host),
     os.environ.get('PORT', args.port_number)
   )
   server = loop.run_until_complete(factory)

--- a/localhost-mqtt-broker/action.yml
+++ b/localhost-mqtt-broker/action.yml
@@ -2,6 +2,10 @@ name: 'Localhost MQTT Broker'
 description: 'Starts an MQTT Broker using Python. For TLS connections (including mutual authentication), connect to localhost:8883. For plaintext connections, connect to localhost:1883.'
 
 inputs:
+  host_address:
+    description: "Host address for echo server."
+    required: false
+    default: "127.0.0.1"
   root-ca-cert-path:
     description: "Root CA certificate file path."
     required: True
@@ -19,5 +23,12 @@ runs:
       run: pip install -r $GITHUB_ACTION_PATH/requirements.txt
       shell: bash
     - name: Run localhost MQTT broker
-      run: python3 $GITHUB_ACTION_PATH/localhost_mqtt_broker.py --root-ca-cert-path=${{ inputs.root-ca-cert-path }} --server-priv-key-path=${{ inputs.server-priv-key-path }} --server-cert-path=${{ inputs.server-cert-path }} &
+      run: |
+        python3 --version
+        # Use the host_address input if provided, otherwise default to 127.0.0.1
+        HOST=${{ inputs.host_address }}
+        if [[ -z "$HOST" ]]; then
+          HOST="127.0.0.1"
+        fi
+        python3 $GITHUB_ACTION_PATH/localhost_mqtt_broker.py --host=$HOST --root-ca-cert-path=${{ inputs.root-ca-cert-path }} --server-priv-key-path=${{ inputs.server-priv-key-path }} --server-cert-path=${{ inputs.server-cert-path }} &
       shell: bash

--- a/localhost-mqtt-broker/localhost_mqtt_broker.py
+++ b/localhost-mqtt-broker/localhost_mqtt_broker.py
@@ -12,6 +12,10 @@ LOCAL_HOST_IP = socket.gethostbyname("localhost")
 # Parse passed in credentials
 parser = ArgumentParser(description='Localhost MQTT broker.')
 
+parser.add_argument('--host',
+                    type=str,
+                    required=True,
+                    help='Host address for the echo server.')
 parser.add_argument('--root-ca-cert-path',
                     type=str,
                     required=True,
@@ -31,12 +35,12 @@ config = {
     "listeners": {
         "default": {
             "type": "tcp",
-            "bind": f"{LOCAL_HOST_IP}:1883",
+            "bind": f"{args.host}:1883",
             "max-connections": 1000,
         },
         "tls": {
             "type": "tcp",
-            "bind": f"{LOCAL_HOST_IP}:8883",
+            "bind": f"{args.host}:8883",
             "max-connections": 1000,
             "ssl": "on",
             "cafile": args.root_ca_cert_path,


### PR DESCRIPTION
***Issue #, if available:***
Failure of +TCP/MQTT demos on the CI when the latest version of +TCP is used.

***Description of changes:***
This PR allows to optionally use the specified IP address as the host address while creating echo server and MQTT broker. 
This change is required to make the latest version of +TCP simulated-based demos work on the CI.

When +TCP simulated demos are run, they don't use the existing endpoint of the host system (Linux/Windows), instead create its own network endpoint. The fixes for loopback-related issues in the latest version of +TCP make it impossible to communicate with loopback addresses that are outside of the demo (in this case, the echo server/MQTT broker runs on the host system's endpoint where simulated demos are run). 

The changes are tested here:

- Branch: https://github.com/tony-josi-aws/FreeRTOS/tree/refs/heads/tcp_v430_release_prep
- CI action run: https://github.com/tony-josi-aws/FreeRTOS/actions/runs/12175302770 
- Using incoming changes in this PR in FreeRTOS repo (forked, above linked branch) CI yaml file: https://github.com/tony-josi-aws/FreeRTOS/blob/refs/heads/tcp_v430_release_prep/.github/workflows/freertos_plus_demos.yml#L460

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
