### PR TITLE
Remove `-q` option to assist in debugging

### DIFF
--- a/.github/workflows/formattingTests.yml
+++ b/.github/workflows/formattingTests.yml
@@ -37,7 +37,6 @@ jobs:
       uses: ./formatting
       with:
         path: formatting/goodFiles
-        exclude-dirs: ",,,"
         exclude-files: "errorFileInDirectory.h, formatErrorTest.h, errorFileInDirectory.c, formatErrorTest.c"
 
     - name: Remove Error Files at Top Directory

--- a/formatting/action.yml
+++ b/formatting/action.yml
@@ -125,7 +125,7 @@ runs:
         # Then run uncrustify with the common config file.
 
         echo -e "${{ env.bashInfo }} fdfind -e c -e h ${args} --exec ~/uncrustify/uncrustify --no-backup --replace --if-changed -c https://github.com/FreeRTOS/CI-CD-Github-Actions/blob/main/formatting/uncrustify.cfg -l C ${{ env.bashEnd }}"
-        fdfind -e c -e h ${args} --exec ~/uncrustify/uncrustify -q --no-backup --replace --if-changed -c $GITHUB_ACTION_PATH/uncrustify.cfg -l C
+        fdfind -e c -e h ${args} --exec ~/uncrustify/uncrustify --no-backup --replace --if-changed -c $GITHUB_ACTION_PATH/uncrustify.cfg -l C
 
         # Replace all trailing whitespace, exclude photo and binary files
         echo -e "${{ env.bashInfo }} Check for Trailing Whitespace ${{ env.bashEnd }}"


### PR DESCRIPTION
*Description of changes:*
Remove `-q` option to assist in debugging when uncrustify fails.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
