### PR TITLE
Handle 429 errors correctly in link verifier

### DIFF
--- a/.github/workflows/pr_checks.yml
+++ b/.github/workflows/pr_checks.yml
@@ -48,7 +48,7 @@ jobs:
               run-spelling-check: true,
               run-complexity: false,
               run-doxygen: false,
-              exclude-dirs: 'ethernet, drivers, FreeRTOS/Demo'
+              exclude-dirs: 'ethernet, drivers, FreeRTOS/Demo, WinPCap, libslirp-version.h, CMSIS, Trace_Recorder_Configuration, ThirdParty, conssole.h, syscalls.c, Demo_IP_Protocols, Reliance-Edge'
             },
             {
               repository: backoffAlgorithm,
@@ -346,7 +346,7 @@ jobs:
               repository: FreeRTOS,
               org: FreeRTOS,
               branch: main,
-              exclude-dirs: 'ethernet, drivers, FreeRTOS/Demo'
+              exclude-dirs: 'ethernet, drivers, FreeRTOS/Demo, WinPCap, libslirp-version.h, CMSIS, Trace_Recorder_Configuration, ThirdParty, conssole.h, syscalls.c, Demo_IP_Protocols, Reliance-Edge'
             },
             {
               repository: FreeRTOS-Cellular-Interface,

--- a/link-verifier/verify-links.py
+++ b/link-verifier/verify-links.py
@@ -197,21 +197,13 @@ def issue_request(method, url, **kwargs):
     retries = 0
 
     while retries < 3:
-        try:
-            r = method(url, **kwargs)
-            if r.status_code == 429:
-                retry_after = int(r.headers.get("Retry-After", 60))
-                time.sleep(retry_after)
-                retries += 1
-            else:
-                return r
-        except Exception as e:
-            if e.code == 429:
-                retry_after = int(e.headers.get("Retry-After", 60))
-                time.sleep(retry_after)
-                retries += 1
-            else:
-                raise e
+        r = method(url, **kwargs)
+        if r.status_code == 429:
+            retry_after = int(r.headers.get("Retry-After", 60))
+            time.sleep(retry_after)
+            retries += 1
+        else:
+            return r
     raise Exception("Max retries exceeded")
 
 def access_url(url):

--- a/link-verifier/verify-links.py
+++ b/link-verifier/verify-links.py
@@ -174,7 +174,7 @@ def parse_file(html_file):
     return HtmlFile(html_file)
 
 def html_name_from_markdown(filename):
-    md_pattern = re.compile("\.md$", re.IGNORECASE)
+    md_pattern = re.compile(r"\.md$", re.IGNORECASE)
     return md_pattern.sub('.html', filename)
 
 def create_html(markdown_file):


### PR DESCRIPTION
Description
------------
Previously, the link verifier did not properly handle 429 (Too Many Requests) responses, preventing proper backoff behavior. This fix implements correct throttling logic to respect rate limits.

This PR also addresses the syntax warning due to invalid escape sequence `\`. This fix is done by using a raw string.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
