### PR TITLE
Update download locations to outside repository content 

### DIFF
--- a/doxygen-generation/action.yml
+++ b/doxygen-generation/action.yml
@@ -43,7 +43,7 @@ runs:
         wget -O "$HOME/doxygen.tgz" "${{ inputs.doxygen_link }}"
         if [ $? -ne 0 ]; then exit 1; fi
 
-        EXPECTED_MD5="b6193a16bc5128597f5affd878dbd7b7"
+        EXPECTED_MD5="b6193a16bc5128597f5affd878dbd7b8"
         GENERATED_MD5=$(md5sum "$HOME/doxygen.tgz" | awk '{print $1}')
 
         if [ "$GENERATED_MD5" = "$EXPECTED_MD5" ]; then

--- a/doxygen-generation/action.yml
+++ b/doxygen-generation/action.yml
@@ -40,9 +40,9 @@ runs:
     - name: Install Doxygen
       shell: bash
       run: |
-        wget -O doxygen.tgz "${{ inputs.doxygen_link }}"
+        wget -O "$HOME/doxygen.tgz" "${{ inputs.doxygen_link }}"
         if [ $? -ne 0 ]; then exit 1; fi
-        sudo tar --strip-components=1 -xzf doxygen.tgz -C /usr/local
+        sudo tar --strip-components=1 -xzf "$HOME/doxygen.tgz" -C /usr/local
         sudo apt-get install -y ${{ inputs.doxygen_dependencies }}
 
     - name: Generate doxygen

--- a/doxygen-generation/action.yml
+++ b/doxygen-generation/action.yml
@@ -42,8 +42,18 @@ runs:
       run: |
         wget -O "$HOME/doxygen.tgz" "${{ inputs.doxygen_link }}"
         if [ $? -ne 0 ]; then exit 1; fi
-        sudo tar --strip-components=1 -xzf "$HOME/doxygen.tgz" -C /usr/local
-        sudo apt-get install -y ${{ inputs.doxygen_dependencies }}
+
+        EXPECTED_MD5="b6193a16bc5128597f5affd878dbd7b7"
+        GENERATED_MD5=$(md5sum "$HOME/doxygen.tgz" | awk '{print $1}')
+
+        if [ "$GENERATED_MD5" = "$EXPECTED_MD5" ]; then
+          sudo tar --strip-components=1 -xzf "$HOME/doxygen.tgz" -C /usr/local
+          sudo apt-get install -y ${{ inputs.doxygen_dependencies }}
+        else
+          echo -e "${{ env.bashFail }} MD5 checksum verification failed for doxygen.tgz ${{ env.bashEnd }}"
+          echo -e "${{ env.bashFail }} ${{ env.stepName }} ${{ env.bashEnd }}"
+          exit -1          
+        fi
 
     - name: Generate doxygen
       working-directory: ./doxygen_source

--- a/doxygen-generation/action.yml
+++ b/doxygen-generation/action.yml
@@ -43,7 +43,7 @@ runs:
         wget -O "$HOME/doxygen.tgz" "${{ inputs.doxygen_link }}"
         if [ $? -ne 0 ]; then exit 1; fi
 
-        EXPECTED_MD5="b6193a16bc5128597f5affd878dbd7b8"
+        EXPECTED_MD5="b6193a16bc5128597f5affd878dbd7b7"
         GENERATED_MD5=$(md5sum "$HOME/doxygen.tgz" | awk '{print $1}')
 
         if [ "$GENERATED_MD5" = "$EXPECTED_MD5" ]; then

--- a/link-verifier/action.yml
+++ b/link-verifier/action.yml
@@ -49,18 +49,6 @@ runs:
       # ${{ env.stepName }}
       echo -e "::group::${{ env.bashInfo }} ${{ env.stepName }} ${{ env.bashEnd }}"
 
-      wget https://github.com/jgm/pandoc/releases/download/2.11/pandoc-2.11-1-amd64.deb -O pandoc.deb
-      sudo dpkg -i pandoc.deb
-
-      rm pandoc.deb
-      sudo apt install debsums
-
-      sudo debsums pandoc
-      sudo type -p curl >/dev/null || sudo apt install curl -y
-      curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | sudo dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg
-      sudo chmod go+r /usr/share/keyrings/githubcli-archive-keyring.gpg
-      echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | sudo tee /etc/apt/sources.list.d/github-cli.list > /dev/null
-
       sudo apt update
       sudo apt install -y gh
       sudo apt install pandoc -y

--- a/set_up_cbmc_runner/action.yml
+++ b/set_up_cbmc_runner/action.yml
@@ -67,10 +67,10 @@ runs:
       run: |
         # ${{ env.stepName }}
         echo -e "::group::${{ env.bashInfo }} ${{ env.stepName }} ${{ env.bashEnd }}"
-        curl -o cbmc.deb -L \
+        curl -o "$HOME/cbmc.deb" -L \
           https://github.com/diffblue/cbmc/releases/download/cbmc-${{ inputs.cbmc_version }}/ubuntu-20.04-cbmc-${{ inputs.cbmc_version }}-Linux.deb
-        sudo dpkg -i ./cbmc.deb
-        rm ./cbmc.deb
+        sudo dpkg -i "$HOME/cbmc.deb"
+        rm "$HOME/cbmc.deb"
         echo -e "::endgroup::"
         echo -e "${{ env.bashPass }} ${{ env.stepName }} ${{ env.bashEnd }}"
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This PR updates all download commands (such as curl) to download files outside the repository content.

This was done to ensure that all download commands (wget, curl or something else) specify explicit output filenames, do SHA256 hash validation and download files to directories inaccessible to PR authors.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
